### PR TITLE
Base class for queue/exchange declaration responses

### DIFF
--- a/src/main/scala/io/scalac/amqp/Exchange.scala
+++ b/src/main/scala/io/scalac/amqp/Exchange.scala
@@ -3,16 +3,16 @@ package io.scalac.amqp
 
 object Exchange {
   /** Notification received after exchange is declared. */
-  final case class DeclareOk()
+  final case class DeclareOk() extends Method
 
   /** Notification received after exchange is deleted. */
-  final case class DeleteOk()
+  final case class DeleteOk() extends Method
 
   /** Notification received after exchange to exchange binding is added. */
-  final case class BindOk()
+  final case class BindOk() extends Method
 
   /** Notification received after exchange to exchange binding is removed. */
-  final case class UnbindOk()
+  final case class UnbindOk() extends Method
 }
 
 /** Exchanges are AMQP entities where messages are sent.

--- a/src/main/scala/io/scalac/amqp/Method.scala
+++ b/src/main/scala/io/scalac/amqp/Method.scala
@@ -1,0 +1,3 @@
+package io.scalac.amqp
+
+trait Method

--- a/src/main/scala/io/scalac/amqp/Queue.scala
+++ b/src/main/scala/io/scalac/amqp/Queue.scala
@@ -13,23 +13,23 @@ object Queue {
     /** Number of messages stored in queue. */
     messageCount: Int,
     /** Number of connected consumers. */
-    consumerCount: Int)
+    consumerCount: Int) extends Method
 
   /** Notification received after queue is deleted. */
   final case class DeleteOk(
     /** Number of messages removed together with the queue. */
-    messageCount: Int)
+    messageCount: Int) extends Method
 
   /** Notification received after queue binding is added. */
-  final case class BindOk()
+  final case class BindOk() extends Method
 
   /** Notification received after queue binding is removed. */
-  final case class UnbindOk()
+  final case class UnbindOk() extends Method
 
   /** Notification received after queue is purged. */
   final case class PurgeOk(
     /** Number of messages removed from the queue. */
-    messageCount: Int)
+    messageCount: Int) extends Method
 
   /** Setting the TTL to 0 causes messages to be expired upon reaching a queue unless
     * they can be delivered to a consumer immediately. Thus this provides an alternative


### PR DESCRIPTION
It would be nice to have a base class for all the responses reactive-rabbit gives on declarations and bindings. This would allow to have a resonable type when doing Futures manipulation on multiple declarations.

```
val declarations: List[Future[Method]] = 
      List(
        connection.exchangeDeclare("exchange1"), 
        connection.exchangeDeclare("exchange2"), 
        connection.queueDeclare("queue1"), 
        connection.queueDeclare("queue2"))
```

otherwise the type will be `List[Future[Any]]` which is kind of uninformative.
