### PR TITLE
Support callbacks on connection or channel Shutdown and connection Blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ Connection trait API has two groups of methods: to manage AMQP infrastructure (i
 `publish(exchange, routingKey)` - creates `Subscription` that takes stream of `Message` that will be sent to `exchange` with fixed `routingKey`.  
 `publish(exchange)` - creates `Subscription` for stream of `Routed` (tuple of `Message` and routing key).  
 
+Callback functions can be attached upon connection or channel shutdown through `handleShutdown`.
+[Blocked Connection](https://www.rabbitmq.com/connection-blocked.html) notifications can also be assigned callbacks as well, through `handleBlocking`.

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ libraryDependencies ++= Seq(
   "com.google.guava"         %  "guava"                    % "19.0",             // for MediaType
   "com.google.code.findbugs" %  "jsr305"                   % "3.0.1",
   "org.scalatest"            %% "scalatest"                % "2.2.6"   % "test", // for TCK
+  "org.scalamock"            %% "scalamock-scalatest-support" % "3.2.2" % "test",
   "org.reactivestreams"      %  "reactive-streams-tck"     % "1.0.0"   % "test",
   "com.typesafe.akka"        %% "akka-stream"              % "2.4.2"   % "test"
 )

--- a/src/main/scala/io/scalac/amqp/Connection.scala
+++ b/src/main/scala/io/scalac/amqp/Connection.scala
@@ -1,5 +1,6 @@
 package io.scalac.amqp
 
+import com.rabbitmq.client.ShutdownSignalException
 import com.typesafe.config.{Config, ConfigFactory}
 import io.scalac.amqp.impl.RabbitConnection
 import org.reactivestreams.{Publisher, Subscriber}
@@ -20,6 +21,15 @@ object Connection {
 
 
 trait Connection {
+  /** Attach callback on connection or channel shutdown.
+    * @param f function used in constructing the ShutdownListener */
+  def handleShutdown(f: ShutdownSignalException => Unit): Unit
+
+  /** Attach callbacks when connection is blocked and unblocked for the BlockedListener.
+    * @param blockFunc called on connection.blocked notification
+    * @param unblockFunc called on connection.unblocked notification */
+  def handleBlocking(blockFunc: String => Unit)(unblockFunc: () => Unit): Unit
+
   /** Declare an exchange.
     * This invocation does nothing if exchange with identical parameters already exists. */
   def exchangeDeclare(exchange: Exchange): Future[Exchange.DeclareOk]

--- a/src/main/scala/io/scalac/amqp/impl/RabbitConnection.scala
+++ b/src/main/scala/io/scalac/amqp/impl/RabbitConnection.scala
@@ -123,8 +123,7 @@ private[amqp] class RabbitConnection(settings: ConnectionSettings) extends Conne
 
   override def publish(exchange: String, routingKey: String) =
     new Subscriber[Message] {
-      val channel = underlying.createChannel()
-      val delegate = new ExchangeSubscriber(channel, exchange)
+      val delegate = new ExchangeSubscriber(underlying, exchange)
 
       override def onError(t: Throwable) = delegate.onError(t)
       override def onSubscribe(s: Subscription) = delegate.onSubscribe(s)
@@ -135,12 +134,12 @@ private[amqp] class RabbitConnection(settings: ConnectionSettings) extends Conne
           routingKey = routingKey,
           message = message))
 
-      override def toString = s"ExchangeSubscriber(channel=$channel, exchange=$exchange, routingKey=$routingKey)"
+      override def toString = s"ExchangeSubscriber(exchange=$exchange, routingKey=$routingKey)"
     }
 
   override def publish(exchange: String) =
     new ExchangeSubscriber(
-      channel = underlying.createChannel(),
+      connection = underlying,
       exchange = exchange)
 
   override def publishDirectly(queue: String) =


### PR DESCRIPTION
- add functional test for handleShutdown using scalamock
- add a note into the readme for handleShutdown and handleBlocking

Ref RabbitMQ Java Client `3.6.1`: 
[ShutdownListener](http://www.rabbitmq.com/releases/rabbitmq-java-client/v3.6.1/rabbitmq-java-client-javadoc-3.6.1/com/rabbitmq/client/ShutdownListener.html)
[BlockedListener](http://www.rabbitmq.com/releases/rabbitmq-java-client/v3.6.1/rabbitmq-java-client-javadoc-3.6.1/com/rabbitmq/client/BlockedListener.html)
