### PR TITLE
Added an implicit parameter for the ExecutionContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import io.scalac.amqp.Connection
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 
 // streaming invoices to Accounting Department
 val connection = Connection()

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ sonatypeSettings
 
 name := "reactive-rabbit"
 
-version := "1.1.2"
+version := "1.2.0"
 
 organization := "io.scalac"
 

--- a/src/main/scala/io/scalac/amqp/Connection.scala
+++ b/src/main/scala/io/scalac/amqp/Connection.scala
@@ -4,17 +4,17 @@ import com.typesafe.config.{Config, ConfigFactory}
 import io.scalac.amqp.impl.RabbitConnection
 import org.reactivestreams.{Publisher, Subscriber}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 
 object Connection {
-  def apply(): Connection =
+  def apply()(implicit ec: ExecutionContext): Connection =
     apply(ConfigFactory.load())
 
-  def apply(config: Config): Connection =
+  def apply(config: Config)(implicit ec: ExecutionContext): Connection =
     apply(ConnectionSettings(config))
 
-  def apply(settings: ConnectionSettings): Connection =
+  def apply(settings: ConnectionSettings)(implicit ec: ExecutionContext): Connection =
     new RabbitConnection(settings)
 }
 

--- a/src/main/scala/io/scalac/amqp/impl/ExchangeSubscriber.scala
+++ b/src/main/scala/io/scalac/amqp/impl/ExchangeSubscriber.scala
@@ -9,12 +9,11 @@ import org.reactivestreams.{Subscriber, Subscription}
 
 import scala.annotation.tailrec
 import scala.collection.immutable.Queue
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.stm.{Ref, atomic}
 import scala.util.control.NonFatal
 
-private[amqp] class ExchangeSubscriber(channel: Channel, exchange: String)
+private[amqp] class ExchangeSubscriber(channel: Channel, exchange: String)(implicit ec: ExecutionContext)
   extends Subscriber[Routed] {
   require(exchange.length <= 255, "exchange.length > 255")
 

--- a/src/main/scala/io/scalac/amqp/impl/QueuePublisher.scala
+++ b/src/main/scala/io/scalac/amqp/impl/QueuePublisher.scala
@@ -4,6 +4,7 @@ import com.rabbitmq.client.{Connection, ShutdownListener, ShutdownSignalExceptio
 import io.scalac.amqp.Delivery
 import org.reactivestreams.{Publisher, Subscriber}
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.stm.Ref
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
@@ -19,7 +20,8 @@ private[amqp] class QueuePublisher(
   /** Number of unacknowledged messages in the flight. It's beneficial to have this number higher
     * than 1 due to improved throughput. Setting this number to high may increase memory usage -
     * depending on average message size and speed of subscribers. */
-  prefetch: Int = 20) extends Publisher[Delivery] {
+  prefetch: Int = 20)
+  (implicit ec: ExecutionContext) extends Publisher[Delivery] {
 
   require(prefetch > 0, "prefetch <= 0")
 

--- a/src/main/scala/io/scalac/amqp/impl/QueueSubscription.scala
+++ b/src/main/scala/io/scalac/amqp/impl/QueueSubscription.scala
@@ -7,13 +7,13 @@ import org.reactivestreams.{Subscriber, Subscription}
 
 import scala.annotation.tailrec
 import scala.collection.immutable.Queue
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.stm.{Ref, atomic}
 import scala.util.control.NonFatal
 
 
 private[amqp] class QueueSubscription(channel: Channel, queue: String, subscriber: Subscriber[_ >: Delivery])
+                                     (implicit ec: ExecutionContext)
   extends DefaultConsumer(channel) with Subscription {
 
   val demand = Ref(0L)

--- a/src/main/scala/io/scalac/amqp/impl/RabbitConnection.scala
+++ b/src/main/scala/io/scalac/amqp/impl/RabbitConnection.scala
@@ -7,10 +7,9 @@ import io.scalac.amqp._
 import org.reactivestreams.{Subscriber, Subscription}
 
 import scala.collection.JavaConversions._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Future, blocking}
+import scala.concurrent.{ExecutionContext, Future, blocking}
 
-private[amqp] class RabbitConnection(settings: ConnectionSettings) extends Connection {
+private[amqp] class RabbitConnection(settings: ConnectionSettings)(implicit ec: ExecutionContext) extends Connection {
   val factory = Conversions.toConnectionFactory(settings)
   val isAutoRecovering = settings.automaticRecovery
   val addresses: Array[Address] = settings.addresses.map(address ⇒

--- a/src/test/scala/io/scalac/amqp/impl/ExchangeSubscriberBlackboxSpec.scala
+++ b/src/test/scala/io/scalac/amqp/impl/ExchangeSubscriberBlackboxSpec.scala
@@ -9,6 +9,7 @@ import org.reactivestreams.tck.{SubscriberBlackboxVerification, TestEnvironment}
 import org.scalatest.testng.TestNGSuiteLike
 import org.testng.annotations.AfterSuite
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class ExchangeSubscriberBlackboxSpec(defaultTimeout: FiniteDuration) extends SubscriberBlackboxVerification[Routed](

--- a/src/test/scala/io/scalac/amqp/impl/QueuePublisherSpec.scala
+++ b/src/test/scala/io/scalac/amqp/impl/QueuePublisherSpec.scala
@@ -9,6 +9,7 @@ import org.reactivestreams.{Publisher, Subscriber, Subscription}
 import org.scalatest.testng.TestNGSuiteLike
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 /** You need to have RabbitMQ server to run these tests.


### PR DESCRIPTION
- Rather than importing the global ExecutionContext, allow the caller to
  specify the ExecutionContext.
- Changed the minor version to 1.2.0 since this is a breaking change to the
  API. All the caller needs to do to maintain the existing behaviour, however,
  is import the global ExecutionContext, if it has not already been imported,
  as evidenced by the changes to the tests in this commit.