### PR TITLE
Relax the Content-Type Parsing

### DIFF
--- a/src/main/scala/io/scalac/amqp/Message.scala
+++ b/src/main/scala/io/scalac/amqp/Message.scala
@@ -1,6 +1,5 @@
 package io.scalac.amqp
 
-import com.google.common.net.MediaType
 import io.scalac.amqp.Message.{PriorityMax, PriorityMin}
 import java.time.ZonedDateTime
 
@@ -23,7 +22,7 @@ final case class Message(
     * the content-type SHOULD NOT be set, allowing the recipient to determine the actual type.
     * Where the section is known to be truly opaque binary data, the content-type SHOULD be set
     * to application/octet-stream. */
-  contentType: Option[MediaType] = None,
+  contentType: Option[String] = None,
 
   /** When present, describes additional content encodings applied to the application-data,
     * and thus what decoding mechanisms need to be applied in order to obtain the media-type

--- a/src/main/scala/io/scalac/amqp/impl/Conversions.scala
+++ b/src/main/scala/io/scalac/amqp/impl/Conversions.scala
@@ -5,7 +5,6 @@ import java.util.Date
 import java.util.concurrent.TimeUnit
 
 import com.google.common.collect.ImmutableMap
-import com.google.common.net.MediaType
 import com.rabbitmq.client.{AMQP, ConnectionFactory, Envelope}
 import io.scalac.amqp._
 
@@ -60,7 +59,7 @@ private object Conversions {
 
     Message(
       body            = body,
-      contentType     = Option(properties.getContentType).map(MediaType.parse),
+      contentType     = Option(properties.getContentType),
       contentEncoding = Option(properties.getContentEncoding),
       headers         = Option(properties.getHeaders).map(_.toMap.mapValues(_.toString)).getOrElse(Map()),
       mode            = toDeliveryMode(properties.getDeliveryMode),
@@ -96,7 +95,7 @@ private object Conversions {
     }
 
     new AMQP.BasicProperties.Builder()
-      .contentType(message.contentType.map(_.toString).orNull)
+      .contentType(message.contentType.orNull)
       .contentEncoding(message.contentEncoding.orNull)
       .headers(message.headers)
       .deliveryMode(toDeliveryMode(message.mode))

--- a/src/test/scala/io/scalac/amqp/impl/ConversionsSpec.scala
+++ b/src/test/scala/io/scalac/amqp/impl/ConversionsSpec.scala
@@ -2,6 +2,7 @@ package io.scalac.amqp.impl
 
 import javax.net.ssl.SSLContext
 
+import com.rabbitmq.client.AMQP.BasicProperties
 import io.scalac.amqp.{Address, ConnectionSettings}
 import org.scalatest.FlatSpec
 
@@ -29,5 +30,19 @@ class ConversionsSpec extends FlatSpec {
     val connectionFactory = Conversions.toConnectionFactory(settings)
 
     assert(connectionFactory.isSSL)
+  }
+
+
+  it should "handle valid content-type headers" in {
+    val props = new BasicProperties.Builder()
+      .contentType("application/json")
+      .build
+
+    val mediaType = Conversions
+      .toMessage(props, Array[Byte]())
+      .contentType
+      .get
+
+    assert(mediaType == "application/json")
   }
 }


### PR DESCRIPTION
Prevent exceptions for invalid Content-Type headers